### PR TITLE
Fix CXXSTD_REGEXP to work with msvc-style flags

### DIFF
--- a/functions
+++ b/functions
@@ -14,7 +14,7 @@ function _test_re {
 }
 
 # Used by replace_cxxstd, remove_cxxstd
-CXXSTD_REGEXP="[-/]std=c\+\+[0-9][0-9]"
+CXXSTD_REGEXP="[-/]std(=|:)c\+\+[0-9][0-9]"
 
 # Search $3... for a switch matching $2 using $1 (_test_* above)
 # If found, echo index (0 for $3, 1 for $4...) and return 0.


### PR DESCRIPTION
Fixes the remove_cxxstd helper function to work with `/std:c++17` style flags